### PR TITLE
Fix branch marker calculation in getFolderStructure

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -122,16 +122,17 @@ function getFolderStructure(rootPath, ignoreFiles, level) {
   let output = ''
 
   if (fs.existsSync(rootPath)) {
-    const files = fs.readdirSync(rootPath)
-    files.forEach((file, index) => {
-      const fullPath = path.join(rootPath, file)
-      const relativePath = path.relative(rootPath, fullPath)
+    const entries = fs.readdirSync(rootPath)
+    const visibleEntries = entries
+      .map(file => {
+        const fullPath = path.join(rootPath, file)
+        const relativePath = path.relative(rootPath, fullPath)
+        return { file, fullPath, relativePath }
+      })
+      .filter(({ relativePath }) => !matchesPattern(relativePath, ignoreFiles))
 
-      if (matchesPattern(relativePath, ignoreFiles)) {
-        return
-      }
-
-      const isLastFile = index === files.length - 1
+    visibleEntries.forEach(({ file, fullPath }, index) => {
+      const isLastFile = index === visibleEntries.length - 1
       const prefix = level === 0 ? '' : isLastFile ? '└── ' : '├── '
       const indent = ' '.repeat(level * 4) + (level > 0 ? prefix : '')
 


### PR DESCRIPTION
### Motivation
- Correct branch symbol (`├──` / `└──`) selection so `isLastFile` reflects visible items when entries are filtered by `matchesPattern`, avoiding incorrect tree markers for ignored files.

### Description
- In `getFolderStructure` build `entries` via `fs.readdirSync(rootPath)`, map each to `{ file, fullPath, relativePath }`, and filter with `matchesPattern` to produce `visibleEntries`.
- Iterate `visibleEntries` and compute `isLastFile` from `visibleEntries.length - 1`, while preserving the original recursion and output formatting.

### Testing
- Ran `node --check extension.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1721afc5c832789244fe3d296870c)