### PR TITLE
Fix typos and add ESLint flat config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ VSCode Project Structure is a Visual Studio Code extension that allows you to ge
 - Open the command palette (Ctrl+Shift+P on Windows/Linux, Cmd+Shift+P on macOS).
 - Type `Generate Project Structure` and select the desired command:
   - `All files`: Generates `project_structure.txt` containing **Project Structure** and **File Contents** for all files, except those matching the **ignore patterns**,
-  - `Filtered files`: Also generates `project_structure_filtered.txt` containing both the the **Project Structure** for all files (except those matching the **ignore patterns**), and **File Contents** only for those matching the **filter patterns**
+  - `Filtered files`: Also generates `project_structure_filtered.txt` containing both the **Project Structure** for all files (except those matching the **ignore patterns**), and **File Contents** only for those matching the **filter patterns**
 - Wait for the extension to finish generating the file.
 - Use `.project_structure_ignore` to list your **ignore patterns**,
 - Use `.project_structure_filter` to list your **filter patterns**
 
 By default:
 
-- **Ignore patterns** cinlude the ones defined in your `.gitignore` file
+- **Ignore patterns** include the ones defined in your `.gitignore` file
 - all configuration and output files are located in the `docs` directory
 
 ## Examples

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+module.exports = [
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2018,
+      sourceType: 'module',
+      globals: {
+        require: 'readonly',
+        module: 'readonly',
+        exports: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        describe: 'readonly',
+        it: 'readonly',
+        before: 'readonly',
+        after: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly'
+      }
+    },
+    rules: {
+      'no-const-assign': 'warn',
+      'no-this-before-super': 'warn',
+      'no-undef': 'warn',
+      'no-unreachable': 'warn',
+      'no-unused-vars': 'warn',
+      'constructor-super': 'warn',
+      'valid-typeof': 'warn'
+    }
+  }
+];

--- a/extension.js
+++ b/extension.js
@@ -42,7 +42,7 @@ function generateProjectStructure(applyFilter = false) {
   // Defines the path to the root folder of the workspace, displays an error message if no workspace is open
   const rootPath = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined
   if (!rootPath) {
-    vscode.window.showErrorMessage('Fab! No workspace folder is open')
+    vscode.window.showErrorMessage('No workspace folder is open')
     return
   }
 
@@ -83,7 +83,7 @@ function generateProjectStructure(applyFilter = false) {
     if (!fs.existsSync(ignoreFilePath)) {
       fs.writeFileSync(ignoreFilePath, '')
     }
-    // iset the output path to project_structure.txt
+    // set the output path to project_structure.txt
     outputPath = path.join(outputFolderPath, 'project_structure.txt')
   }
 


### PR DESCRIPTION
## Summary
- fix minor typos in README
- fix typo in extension output message
- add ESLint flat config so ESLint v9 can run

## Testing
- `npm test` *(fails: Cannot find module '@vscode/test-electron')*

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_687611d672648327be792f27fd802aa7)