### PR TITLE
Fix typos and clarify settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ VSCode Project Structure is a Visual Studio Code extension that allows you to ge
 - Open the command palette (Ctrl+Shift+P on Windows/Linux, Cmd+Shift+P on macOS).
 - Type `Generate Project Structure` and select the desired command:
   - `All files`: Generates `project_structure.txt` containing **Project Structure** and **File Contents** for all files, except those matching the **ignore patterns**,
-  - `Filtered files`: Also generates `project_structure_filtered.txt` containing both the the **Project Structure** for all files (except those matching the **ignore patterns**), and **File Contents** only for those matching the **filter patterns**
+  - `Filtered files`: Also generates `project_structure_filtered.txt` containing both the **Project Structure** for all files (except those matching the **ignore patterns**), and **File Contents** only for those matching the **filter patterns**
 - Wait for the extension to finish generating the file.
 - Use `.project_structure_ignore` to list your **ignore patterns**,
 - Use `.project_structure_filter` to list your **filter patterns**
 
 By default:
 
-- **Ignore patterns** cinlude the ones defined in your `.gitignore` file
+- **Ignore patterns** include the ones defined in your `.gitignore` file
 - all configuration and output files are located in the `docs` directory
 
 ## Examples
@@ -61,7 +61,7 @@ Visual Studio Code version 1.76.0 or higher.
 
 To change extension settings, open your Visual Studio Code settings (File > Preferences > Settings), and search for "Project Structure". You can then:
 
-- Exclude `.gitignore` from the **ignore patterns** (true by default)
+- Include `.gitignore` patterns in the ignore list (enabled by default)
 - Change the configuration/output folder (`docs` by default).
 
 ## Release Notes


### PR DESCRIPTION
## Summary
- fix double-word typo in Usage instructions
- correct typo 'cinlude'
- clarify that `.gitignore` patterns are included by default

## Testing
- `npm test` *(fails: ESLint couldn't find config)*

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6875ecccfa8083279a56d9187e9574c3)