### PR TITLE
Add type validation and fallback for outputFolderPath setting

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -49,8 +49,14 @@ function generateProjectStructure(applyFilter = false) {
   // Defines the configuration object
   const config = vscode.workspace.getConfiguration('vscodeProjectStructure')
 
+  const configured = config.get('outputFolderPath')
+  // Guard the config type so path.join always receives a string.
+  const hasValidOutputFolder = typeof configured === 'string' && configured.trim() !== ''
+  if (!hasValidOutputFolder) {
+    vscode.window.showWarningMessage('Invalid "outputFolderPath" setting. Falling back to default "docs" folder.')
+  }
   // Defines the path to the output folder, if not defined set it to "docs"
-  const outputFolderName = config.get('outputFolderPath') || 'docs'
+  const outputFolderName = hasValidOutputFolder ? configured : 'docs'
   const outputFolderPath = path.join(rootPath, outputFolderName)
 
   // Creates the output folder if it doesn't exist


### PR DESCRIPTION
### Motivation
- Prevent `path.join` from receiving non-string or empty configuration values by validating `outputFolderPath` and falling back to a safe default.

### Description
- Read the configuration into `configured` and validate it with `typeof configured === 'string' && configured.trim() !== ''`.
- Use `configured` when valid or fallback to `'docs'` via `outputFolderName`, and add an inline comment explaining the type guard.
- Display a warning with `vscode.window.showWarningMessage` when the configured value is invalid.

### Testing
- Ran `npm test --silent`, however the test run failed due to an external API JSON parse error (`Failed to parse response from https://update.code.visualstudio.com/api/releases/stable as JSON`) which prevented the test suite from completing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1721d1e608327801b3413b6f5845e)