### PR TITLE
Fix filtered content matching to use workspace-relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ VSCode Project Structure is a Visual Studio Code extension that allows you to ge
   - `Filtered files`: Also generates `project_structure_filtered.txt` containing both the the **Project Structure** for all files (except those matching the **ignore patterns**), and **File Contents** only for those matching the **filter patterns**
 - Wait for the extension to finish generating the file.
 - Use `.project_structure_ignore` to list your **ignore patterns**,
-- Use `.project_structure_filter` to list your **filter patterns**
+- Use `.project_structure_filter` to list your **filter patterns** (matched against workspace-relative paths, e.g. `src/index.js`)
 
 By default:
 
@@ -46,7 +46,7 @@ dist
 *.log
 ```
 
-This `.project_structure_filter` file will cause Project Structure to only provide full content of the package.json file, as well as any in the src folder (excluding those that match the ignore pattern):
+This `.project_structure_filter` file will cause Project Structure to only provide full content of `package.json`, as well as files under `src` (patterns are matched against workspace-relative paths, excluding those that match the ignore pattern):
 
 ```
 src

--- a/extension.js
+++ b/extension.js
@@ -177,7 +177,7 @@ function getFileContents(rootPath, ignoreFiles, filterFiles, applyFilter = false
   filePaths.forEach(filePath => {
     // If apply filter is on, ignore files that don't match the filter patterns
     const relativePath = path.relative(rootPath, filePath)
-    if (applyFilter && !matchesPattern(filePath, filterFiles)) {
+    if (applyFilter && !matchesPattern(relativePath, filterFiles)) {
       return
     }
     output += `\n--- File: ${relativePath} ---\n`


### PR DESCRIPTION
### Motivation
- Fix a bug where filter patterns were compared against absolute file paths instead of the workspace-relative path, causing `.project_structure_filter` patterns to not match as intended.

### Description
- Updated `getFileContents` in `extension.js` to use the precomputed `relativePath` when calling `matchesPattern` for filter checks, and updated `README.md` to clarify that `.project_structure_filter` patterns are matched against workspace-relative paths.

### Testing
- Ran the extension test script with `npm test --silent`, which failed in this environment due to an external VS Code update JSON parsing error and not because of the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1721994b88327a72ab11f318f7fdc)