### PR TITLE
Add integration tests, extract pattern matcher, and export core generators for testing

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@
 const vscode = require('vscode')
 const fs = require('fs')
 const path = require('path')
+const { matchesPattern } = require('./patternMatcher')
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -187,25 +188,13 @@ function getFileContents(rootPath, ignoreFiles, filterFiles, applyFilter = false
   return output
 }
 
-function matchesPattern(relativePath, listOfPatterns) {
-  for (const pattern of listOfPatterns) {
-    if (pattern.startsWith('*')) {
-      const fileExtension = path.extname(relativePath)
-      if (fileExtension === pattern.slice(1)) {
-        return true
-      }
-    } else if (relativePath.includes(pattern)) {
-      return true
-    }
-  }
-
-  return false
-}
-
 // This method is called when your extension is deactivated
 function deactivate() {}
 
 module.exports = {
   activate,
-  deactivate
+  deactivate,
+  generateProjectStructure,
+  getFolderStructure,
+  getFileContents
 }

--- a/patternMatcher.js
+++ b/patternMatcher.js
@@ -1,0 +1,20 @@
+const path = require('path')
+
+function matchesPattern(relativePath, listOfPatterns) {
+  for (const pattern of listOfPatterns) {
+    if (pattern.startsWith('*')) {
+      const fileExtension = path.extname(relativePath)
+      if (fileExtension === pattern.slice(1)) {
+        return true
+      }
+    } else if (relativePath.includes(pattern)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+module.exports = {
+  matchesPattern
+}

--- a/test/fixtures/basic-project/.gitignore
+++ b/test/fixtures/basic-project/.gitignore
@@ -1,0 +1,3 @@
+logs/
+*.log
+secret.txt

--- a/test/fixtures/basic-project/README.md
+++ b/test/fixtures/basic-project/README.md
@@ -1,0 +1,1 @@
+# Fixture Project

--- a/test/fixtures/basic-project/secret/visible.txt
+++ b/test/fixtures/basic-project/secret/visible.txt
@@ -1,0 +1,1 @@
+visible content

--- a/test/fixtures/basic-project/src/index.js
+++ b/test/fixtures/basic-project/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello fixture');

--- a/test/suite/extension.test.js
+++ b/test/suite/extension.test.js
@@ -1,15 +1,77 @@
-const assert = require('assert');
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-const vscode = require('vscode');
-// const myExtension = require('../extension');
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const vscode = require('vscode')
+const { matchesPattern } = require('../../patternMatcher')
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+  const fixturePath = path.resolve(__dirname, '../fixtures/basic-project')
+  const docsPath = path.join(fixturePath, 'docs')
 
-	test('Sample test', () => {
-		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-	});
-});
+  suiteSetup(async () => {
+    const existing = vscode.workspace.workspaceFolders || []
+    if (existing.length === 0 || existing[0].uri.fsPath !== fixturePath) {
+      vscode.workspace.updateWorkspaceFolders(0, existing.length, { uri: vscode.Uri.file(fixturePath) })
+      await new Promise(resolve => setTimeout(resolve, 600))
+    }
+
+    await vscode.workspace.getConfiguration('vscodeProjectStructure').update('outputFolderPath', 'docs', vscode.ConfigurationTarget.Workspace)
+    await vscode.workspace.getConfiguration('vscodeProjectStructure').update('useGitIgnore', true, vscode.ConfigurationTarget.Workspace)
+  })
+
+  setup(() => {
+    const outputFiles = ['project_structure.txt', 'project_structure_filtered.txt', '.project_structure_ignore', '.project_structure_filter']
+    outputFiles.forEach(file => {
+      const fullPath = path.join(docsPath, file)
+      if (fs.existsSync(fullPath)) {
+        fs.unlinkSync(fullPath)
+      }
+    })
+  })
+
+  test('commands are registered', async () => {
+    const commands = await vscode.commands.getCommands(true)
+    assert.ok(commands.includes('extension.generateProjectStructure'))
+    assert.ok(commands.includes('extension.generateFilteredProjectStructure'))
+  })
+
+  test('generateProjectStructure writes output with sections and applies ignore rules', async () => {
+    fs.mkdirSync(docsPath, { recursive: true })
+    fs.writeFileSync(path.join(docsPath, '.project_structure_ignore'), 'README.md')
+
+    await vscode.commands.executeCommand('extension.generateProjectStructure')
+
+    const outputPath = path.join(docsPath, 'project_structure.txt')
+    assert.ok(fs.existsSync(outputPath), 'project_structure.txt should exist')
+
+    const output = fs.readFileSync(outputPath, 'utf-8')
+    assert.ok(output.includes('--- Folder Structure ---'))
+    assert.ok(output.includes('--- File Contents ---'))
+    assert.ok(output.includes('src/index.js'))
+    assert.ok(!output.includes('logs/app.log'))
+    assert.ok(!output.includes('secret.txt'))
+    assert.ok(!output.includes('README.md'))
+  })
+
+  test('generateFilteredProjectStructure includes only filtered files', async () => {
+    fs.mkdirSync(docsPath, { recursive: true })
+    fs.writeFileSync(path.join(docsPath, '.project_structure_filter'), 'src/index.js')
+
+    await vscode.commands.executeCommand('extension.generateFilteredProjectStructure')
+
+    const outputPath = path.join(docsPath, 'project_structure_filtered.txt')
+    assert.ok(fs.existsSync(outputPath), 'project_structure_filtered.txt should exist')
+
+    const output = fs.readFileSync(outputPath, 'utf-8')
+    assert.ok(output.includes('--- Folder Structure ---'))
+    assert.ok(output.includes('--- File Contents ---'))
+    assert.ok(output.includes('--- File: src/index.js ---'))
+    assert.ok(!output.includes('--- File: README.md ---'))
+  })
+
+  test('matchesPattern handles extension and substring patterns', () => {
+    assert.strictEqual(matchesPattern('src/app.log', ['*.log']), true)
+    assert.strictEqual(matchesPattern('docs/README.md', ['README.md']), true)
+    assert.strictEqual(matchesPattern('src/index.js', ['*.ts', 'assets']), false)
+  })
+})


### PR DESCRIPTION
### Motivation
- Improve test coverage for command registration and ignore/filter behavior by adding integration-style tests that exercise the extension end-to-end.
- Make pattern matching logic testable in isolation to allow deterministic unit tests for ignore/filter rules.
- Increase testability of the core generation logic by exporting functions so they can be invoked from tests.

### Description
- Add `patternMatcher.js` that contains `matchesPattern` and replace the inline matcher in `extension.js` with `const { matchesPattern } = require('./patternMatcher')`.
- Exported core functions from `extension.js`: `generateProjectStructure`, `getFolderStructure`, and `getFileContents` to facilitate direct testing.
- Add a workspace fixture at `test/fixtures/basic-project` with a small tree and a `.gitignore` to exercise ignore rules and filtering behavior.
- Replace the sample test with `test/suite/extension.test.js` that verifies command registration via `vscode.commands.getCommands(true)`, ensures output files (`project_structure.txt` / `project_structure_filtered.txt`) are created and contain the `--- Folder Structure ---` and `--- File Contents ---` sections, exercises ignore/filter cases, and unit-tests `matchesPattern` behavior.

### Testing
- `npm run lint` succeeded with no lint errors.
- `npm test` did not complete in this environment because the VS Code test harness failed to fetch release metadata from `https://update.code.visualstudio.com/api/releases/stable`, causing the test runner to abort.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1721ef4408327882c475fea2589f8)